### PR TITLE
Update keyes_mecanum_Car_V2.py

### DIFF
--- a/docs/Python/microPython Libraries/keyes_mecanum_Car_V2.py
+++ b/docs/Python/microPython Libraries/keyes_mecanum_Car_V2.py
@@ -11,6 +11,7 @@ class Mecanum_Car_Driver_V2(object):
         self.set_all_pwm(0)
         self.left_led(0)
         self.right_led(0)
+        self.lastEchoDuration = 0
         #sleep(5)
 
     def set_pwm(self, channel, value):


### PR DESCRIPTION
One single variable definition was missing in the _init_ section that made the code of all 3 ultrasonic examples non-executable.